### PR TITLE
state: enable add/remove of self modes

### DIFF
--- a/bogon.go
+++ b/bogon.go
@@ -35,7 +35,7 @@ type state interface {
 	Name() string
 	SetName(newname string)
 
-	ParseModes(modes []string)
+	ParseModes(modes []string, trail string)
 	Encryption() Encryption
 	Rejoin() bool
 }

--- a/state_handlers.go
+++ b/state_handlers.go
@@ -73,7 +73,7 @@ func (c *Client) kickHandler(s ircx.Sender, m *irc.Message) {
 }
 
 func (c *Client) modeHandler(s ircx.Sender, m *irc.Message) {
-	c.state.ParseModes(m.Params)
+	c.state.ParseModes(m.Params, m.Trailing)
 }
 
 func (c *Client) namesHandler(s ircx.Sender, m *irc.Message) {


### PR DESCRIPTION
Also fixes a bug where a user with a zero length string would get parsed, resulting in a panic when the first character of that username would be accessed. 